### PR TITLE
Include missing dependency in install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Required dependencies:
     python3-markdown,
     python3-requests,
     python3-bs4,
+    python3-xlib,
     wkhtmltopdf,
     pandoc,
     html2ps,
@@ -43,5 +44,11 @@ Add the repository and install.
 ```
 sudo add-apt-repository ppa:atareao/utext
 sudo apt update
-sudo apt install utext
+sudo apt-get install -y \
+    gir1.2-gtk-3.0 gir1.2-gdkpixbuf-2.0 gir1.2-webkit-3.0 \
+    gir1.2-gtkspell3-3.0 gir1.2-gtksource-3.0 gir1.2-pango-1.0 \
+    python3-chardet python3-jinja2 python3-markdown \
+    python3-requests python3-bs4 python3-xlib \
+    wkhtmltopdf pandoc html2ps gvfs-bin imagemagick \
+    utext
 ```


### PR DESCRIPTION
The denpdendency to `python3-xlib` was missing completely. Also included the dependencies in the `apt-get install` command